### PR TITLE
remove buffer-size to be more restrictive

### DIFF
--- a/styles/text-clip.xml
+++ b/styles/text-clip.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" buffer-size="128" background-color="#ffffff">
+<Map srs="+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over" background-color="#ffffff">
 
     <Parameters>
         <Parameter name="sizes">1024, 256</Parameter>


### PR DESCRIPTION
Removes `buffer-size` with no effect on reference images.
